### PR TITLE
Security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ tags
 *.swp
 cscope.out
 binutils-2.27.tar.bz2
+binutils-2.32.tar.bz2
 patches/llvm/llvm-3.7.1_old.patch
 patches/llvm/clang-3.7.1_old.patch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+##
+# Dockerfile for popcorn-chameleon
+#
+# This file builds LLVM and all the components necessary for using
+# popcorn-chameleon
+#
+# The LLVM compiler used lives at /usr/local/popcorn/bin/clang
+# The musl wrapper for LLVM is at /usr/local/popcorn/x86_64/bin/musl-clang
+##
+
+
+FROM ubuntu:bionic
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+  bison \
+  ca-certificates \
+  cmake \
+  flex \
+  g++ \
+  gcc \
+  gcc-multilib \
+  git \
+  libelf-dev \
+  python3 \
+  wget \
+  zip \
+  ;
+RUN apt install -y gcc-aarch64-linux-gnu make patch texinfo python-minimal file
+RUN apt install -y libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python-protobuf
+
+# DynamoRIO
+WORKDIR /code
+RUN wget https://github.com/DynamoRIO/dynamorio/releases/download/release_7_0_0_rc1/DynamoRIO-Linux-7.0.0-RC1.tar.gz
+RUN tar xvf DynamoRIO-Linux-7.0.0-RC1.tar.gz
+RUN mkdir -p /usr/local/popcorn
+RUN cp -r DynamoRIO-Linux-7.0.0-RC1/* /usr/local/popcorn
+
+# Popcorn compiler
+WORKDIR /code
+RUN git clone https://github.com/xjtuwxg/popcorn-compiler -b security --depth 1
+
+WORKDIR /code/popcorn-compiler
+RUN ./install_compiler.py --install-all --install-path /usr/local/popcorn --chameleon \
+  && rm -rf /usr/local/popcorn/src
+
+# Download chameleon
+WORKDIR /code
+RUN git clone --recursive https://github.com/ssrg-vt/popcorn-chameleon
+
+WORKDIR /code/popcorn-chameleon
+RUN ./util/install-compel.sh -c ./criu -d
+#RUN ./util/install-compel.sh -c ./criu -i /usr/local/popcorn -d
+
+RUN mkdir build
+WORKDIR /code/popcorn-chameleon/build
+
+RUN cmake -DCMAKE_BUILD_TYPE=Debug \
+  -DDYNAMORIO_INSTALL_DIR=/code/DynamoRIO-Linux-7.0.0-RC1 \
+  -DCOMPEL_INSTALL_DIR=/usr/local/chameleon \
+  -DPOPCORN_INSTALL_DIR=/usr/local/popcorn \
+  ..
+RUN make
+
+RUN sed -i 's/\/usr\/local\/secure-popcorn/\/usr\/local\/popcorn/'\
+  /code/popcorn-chameleon/util/prepare-executable.sh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,13 @@
+# Build the application bianary using popcorn (chameleon) compiler
+build:
+	docker run --rm -v $(PWD)/app:/code/app chameleon:debug make -C /code/app
+
+clean:
+	make -C app clean
+
+# Build chameleon docker image
+docker_img:
+	docker build -t chameleon:debug -f Dockerfile .
+
+run:
+	sudo ./chameleon-debug -b ./app/test.blacklist -- ./app/test

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,18 @@
+# Chameleon docker image
+Three steps to test chameleon using docker:
+
+1. Build the chameleon:debug docker image
+```
+make docker_img
+```
+2. Build the application using this docker image
+```
+make build
+```
+3. Run the application under chameleon-debug
+```
+make run
+```
+
+Note: the chameleon building process is broken, so for now, you can only use a
+pre-built chameleon binary (i.e., `./chameleon-debug`) to run the application.

--- a/docker/app/Makefile
+++ b/docker/app/Makefile
@@ -1,0 +1,11 @@
+CC	= /usr/local/popcorn/x86_64/bin/musl-clang
+CFLAGS	= -static -popcorn-metadata -popcorn-target=x86_64-linux-gnu -secure-popcorn \
+    -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -mno-red-zone
+PREPARE	= /code/popcorn-chameleon/util/prepare-executable.sh
+
+all:
+	$(CC) $(CFLAGS) /code/app/test.c -o /code/app/test
+	$(PREPARE) -f /code/app/test
+
+clean:
+	rm -rf test test.blacklist

--- a/docker/app/test.c
+++ b/docker/app/test.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+int foo(int a, int b)
+{
+	return a + b;
+}
+
+int main()
+{
+	int res = foo(1, 2);
+	printf("res: %d\n", res);
+	return 0;
+}

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -298,7 +298,9 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
         args = ['patch', '-p0', '-d', clang_download_path]
         run_cmd('patch Clang', args, patch_file)
 
+    #=====================================================
     # LLVM-3.7's build system needs clang inside llvm/tools
+    #=====================================================
     if llvm_version == 3.7:
         clang_src = os.path.join(llvm_download_path, 'clang')
         clang_dst = os.path.join(llvm_download_path, 'llvm', 'tools')
@@ -346,10 +348,14 @@ def install_binutils(base_path, install_path, num_threads):
     #=====================================================
     # DOWNLOAD BINUTILS
     #=====================================================
-    print('Downloading binutils source...')
     try:
-        urllib.request.urlretrieve(binutils_url, 'binutils-2.32.tar.bz2')
+        if not os.path.exists('binutils-2.32.tar.bz2'):
+            print('Downloading binutils source...')
+            urllib.request.urlretrieve(binutils_url, 'binutils-2.32.tar.bz2')
+        else:
+            print("Local cache found.")
         with tarfile.open('binutils-2.32.tar.bz2', 'r:bz2') as f:
+            print('Extracting binutils source...')
             f.extractall(path=os.path.join(install_path, 'src'))
     except Exception as e:
         print('Could not download/extract binutils source ({})!'.format(e))

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
-import urllib
+import urllib.request
 
 #================================================
 # GLOBALS
@@ -30,13 +30,12 @@ llvm_targets = {
     'x86_64' : 'X86'
 }
 
-# LLVM 3.7.1 SVN URL
-llvm_url = 'http://llvm.org/svn/llvm-project/llvm/tags/RELEASE_371/final'
-llvm_revision = '320332'
-# Clang SVN URL
-clang_url = 'http://llvm.org/svn/llvm-project/cfe/tags/RELEASE_371/final'
-# Binutils 2.27 URL
-binutils_url = 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.bz2'
+# LLVM 3.7.1 GitHub URL
+llvm_url = 'https://github.com/llvm/llvm-project.git'
+llvm_version = 3.7
+
+# Binutils 2.32 URL
+binutils_url = 'http://ftp.gnu.org/gnu/binutils/binutils-2.32.tar.bz2'
 
 #================================================
 # ARGUMENT PARSING
@@ -204,7 +203,7 @@ def warn_stupid(args):
 def _check_for_prerequisite(prereq):
     try:
         out = subprocess.check_output([prereq, '--version'],
-                                      stderr=subprocess.STDOUT)
+                                      stderr=subprocess.STDOUT).decode("utf-8")
     except Exception:
         print('{} not found!'.format(prereq))
         return None
@@ -219,7 +218,7 @@ def check_for_prerequisites(args):
     gcc_prerequisites = ['x86_64-linux-gnu-g++']
     for target in args.install_targets:
         gcc_prerequisites.append('{}-linux-gnu-gcc'.format(target))
-    other_prerequisites = ['flex', 'bison', 'svn', 'cmake', 'make', 'zip']
+    other_prerequisites = ['flex', 'bison', 'git', 'cmake', 'make', 'zip']
 
     for prereq in gcc_prerequisites:
         out = _check_for_prerequisite(prereq)
@@ -263,7 +262,7 @@ def get_cmd_output(name, cmd, ins=None, use_shell=False):
 def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
 
     llvm_download_path = os.path.join(install_path, 'src', 'llvm')
-    clang_download_path = os.path.join(llvm_download_path, 'tools', 'clang')
+    clang_download_path = os.path.join(llvm_download_path, 'clang')
 
     patch_base = os.path.join(base_path, 'patches', 'llvm')
     llvm_patch_path = os.path.join(patch_base, 'llvm-3.7.1.patch')
@@ -279,22 +278,16 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
     # DOWNLOAD LLVM
     #=====================================================
     print('Downloading LLVM source...')
-    args = ['svn', 'co', llvm_url, llvm_download_path, '-r', llvm_revision]
+    run_cmd('create install_path', ['mkdir', '-p', install_path + '/src'])
+    args = ['git', 'clone', '--depth', '1','-b','release/3.7.x', llvm_url, llvm_download_path]
     run_cmd('download LLVM source', args)
-
-    #=====================================================
-    # DOWNLOAD CLANG
-    #=====================================================
-    print('Downloading Clang source...')
-    args = ['svn', 'co', clang_url, clang_download_path, '-r', llvm_revision]
-    run_cmd('download Clang source', args)
 
     #=====================================================
     # PATCH LLVM
     #=====================================================
     with open(llvm_patch_path, 'r') as patch_file:
         print('Patching LLVM...')
-        args = ['patch', '-p0', '-d', llvm_download_path]
+        args = ['patch', '-p0', '-d', llvm_download_path+'/llvm']
         run_cmd('patch LLVM', args, patch_file)
 
     #=====================================================
@@ -305,11 +298,17 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
         args = ['patch', '-p0', '-d', clang_download_path]
         run_cmd('patch Clang', args, patch_file)
 
+    # LLVM-3.7's build system needs clang inside llvm/tools
+    if llvm_version == 3.7:
+        clang_src = os.path.join(llvm_download_path, 'clang')
+        clang_dst = os.path.join(llvm_download_path, 'llvm', 'tools')
+        shutil.move(clang_src, clang_dst)
+
     #=====================================================
     # BUILD AND INSTALL LLVM
     #=====================================================
     cur_dir = os.getcwd()
-    os.chdir(llvm_download_path)
+    os.chdir(llvm_download_path+'/llvm')
     os.mkdir('build')
     os.chdir('build')
 
@@ -317,6 +316,10 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
     args = ['cmake'] + cmake_flags + ['..']
     run_cmd('run CMake', args)
 
+    if llvm_version > 3.7:
+        print('Installing LLVM headers...')
+        args = ['make', '-j', str(num_threads), 'install-llvm-headers']
+        run_cmd('run Make headers', args)
 
     print('Running Make...')
     args = ['make', '-j', str(num_threads)]
@@ -328,7 +331,7 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
 
 def install_binutils(base_path, install_path, num_threads):
 
-    binutils_install_path = os.path.join(install_path, 'src', 'binutils-2.27')
+    binutils_install_path = os.path.join(install_path, 'src', 'binutils-2.32')
 
     patch_path = os.path.join(base_path, 'patches', 'binutils-gold',
                               'binutils-2.27-gold.patch')
@@ -345,8 +348,8 @@ def install_binutils(base_path, install_path, num_threads):
     #=====================================================
     print('Downloading binutils source...')
     try:
-        urllib.urlretrieve(binutils_url, 'binutils-2.27.tar.bz2')
-        with tarfile.open('binutils-2.27.tar.bz2', 'r:bz2') as f:
+        urllib.request.urlretrieve(binutils_url, 'binutils-2.32.tar.bz2')
+        with tarfile.open('binutils-2.32.tar.bz2', 'r:bz2') as f:
             f.extractall(path=os.path.join(install_path, 'src'))
     except Exception as e:
         print('Could not download/extract binutils source ({})!'.format(e))

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -184,7 +184,7 @@ def postprocess_args(args):
         args.libelf_install = True
         args.libopenpop_install = False
         args.stacktransform_install = True
-        args.migration_install = False
+        args.migration_install = True
         args.stackdepth_install = True
         args.tools_install = True
         args.utils_install = True
@@ -549,9 +549,9 @@ def install_migration(base_path, install_path, num_threads, libmigration_type,
         elif enable_libmigration_timing:
             flags += 'timing'
         args += [flags]
-    run_cmd('make libopenpop', args)
+    run_cmd('make libmigration', args)
     args += ['install']
-    run_cmd('install libopenpop', args)
+    run_cmd('install libmigration', args)
 
     os.chdir(cur_dir)
 

--- a/lib/migration/Makefile
+++ b/lib/migration/Makefile
@@ -76,7 +76,9 @@ LIB_POWERPC := $(BUILD_POWERPC)/$(LIB)
 LIB_X86     := $(BUILD_X86)/$(LIB)
 
 # $(LIB_POWERPC)
-all: $(LIB_ARM) $(LIB_X86)
+## modified by xiaoguang
+#all: $(LIB_ARM) $(LIB_X86)
+all: $(LIB_X86)
 
 %/.dir:
 	@echo " [MKDIR] $*"
@@ -163,10 +165,12 @@ $(LIB_X86): $(HDR_X86) $(OBJ_X86)
 #	@echo " [INSTALL] $(LIB_POWERPC) to $(POPCORN_POWERPC)/lib"
 #	@cp $(LIB_POWERPC) $(POPCORN_POWERPC)/lib
 #	@cp include/migrate.h $(POPCORN_POWERPC)/include
-install: $(LIB_ARM) $(LIB_X86)
-	@echo " [INSTALL] $(LIB_ARM) to $(POPCORN_ARM)/lib"
-	@cp $(LIB_ARM) $(POPCORN_ARM)/lib
-	@cp include/migrate.h $(POPCORN_ARM)/include
+## modified by xiaoguang
+#install: $(LIB_ARM) $(LIB_X86)
+#	@echo " [INSTALL] $(LIB_ARM) to $(POPCORN_ARM)/lib"
+#	@cp $(LIB_ARM) $(POPCORN_ARM)/lib
+#	@cp include/migrate.h $(POPCORN_ARM)/include
+install: $(LIB_X86)
 	@echo " [INSTALL] $(LIB_X86) to $(POPCORN_X86)/lib"
 	@cp $(LIB_X86) $(POPCORN_X86)/lib
 	@cp include/migrate.h $(POPCORN_X86)/include


### PR DESCRIPTION
A few updates (Building LLVM 3.7 on Ubuntu 18.04):

1. Update the LLVM source code repository from SVN to GitHub
2. Upgrade the bin-utils version from 2.27 to 2.32 (picked from the main branch upgrade)
3. Prerequisites fix: svn -> git
4. Temporally enable the migration library (however, the migration library seems not used in Chameleon. Need to confirm)
