### PR TITLE
Installation fixes

### DIFF
--- a/README
+++ b/README
@@ -137,10 +137,11 @@ but may require installing alternate packages and some extra hacking.  It is
   - On Ubuntu 16.04 & higher, x86-64, install the following packages:
       build-essential
       gcc-aarch64-linux-gnu
-+ flex & bison (x86-64 only), needed by binutils
++ flex, bison and texinfo (x86-64 only), needed by binutils
   - On Ubuntu 16.04 & higher, x86-64, install the following packages:
       flex
       bison
+      texinfo (for makeinfo)
 + Python, v2.7 and v3
   - v2 is needed for the installation script and the alignment tool
   - v3 is needed for scripts in util/scripts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,23 +6,32 @@
 #
 # The clang/LLVM compiler lives at /usr/local/popcorn/bin/clang
 # The musl wrapper for LLVM is at /usr/local/popcorn/x86_64/bin/musl-clang
-# 
+#
 # Build application code (located in ./code):
 # docker run --rm -v $(pwd)/app:/code/app <image id> make -C /code/app
 ##
 
-FROM ubuntu:bionic
+FROM ubuntu:jammy
+
+ARG BRANCH_URL="https://github.com/ssrg-vt/popcorn-compiler"
+ARG BRANCH_NAME=main
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-  bison cmake flex g++ gcc git zip make patch texinfo \
-  python3 ca-certificates libelf-dev gcc-aarch64-linux-gnu
-RUN apt-get install -y python-minimal 
+      bison cmake flex g++ gcc git zip make patch texinfo \
+      python3 ca-certificates libelf-dev gcc-aarch64-linux-gnu
+RUN apt-get install -y python2-minimal python-is-python3
 
 WORKDIR /code
-RUN git clone https://github.com/ssrg-vt/popcorn-compiler -b main --depth 1
+RUN git clone ${BRANCH_URL} -b ${BRANCH_NAME} --depth 1
 
 WORKDIR /code/popcorn-compiler
-RUN ./install_compiler.py --install-all --with-popcorn-kernel-5_2 \
-  --libmigration-type=signal_trigger && rm -rf /usr/local/popcorn/src
+RUN ./install_compiler.py \
+      --install-all \
+      --with-popcorn-kernel-5_2 \
+      --libmigration-type=signal_trigger && \
+      rm -rf /usr/local/popcorn/src
 
 ## Use signal 35 to trigger the migration
 ## kill -35 $(pidof <popcorn bin>)

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -1001,7 +1001,7 @@ def install_utils(base_path, install_path, num_threads):
 
     tmp = install_path.replace('/', '\/')
     sed_cmd = "sed -i -e 's/^POPCORN := .*/POPCORN := {}/g' " \
-              "./util/Makefile.template".format(tmp)
+              "{}/util/Makefile.template".format(tmp, base_path)
     run_cmd('update Makefile template', sed_cmd, use_shell=True)
 
     #=====================================================

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -1008,8 +1008,9 @@ def install_utils(base_path, install_path, num_threads):
     # COPY SCRIPTS
     #=====================================================
     print("Copying util/scripts to {}/bin...".format(install_path))
-    for item in os.listdir('./util/scripts'):
-        s = os.path.join('./util', 'scripts', item)
+    scripts_dir = os.path.join(base_path, 'util', 'scripts')
+    for item in os.listdir(scripts_dir):
+        s = os.path.join(scripts_dir, item)
         d = os.path.join(os.path.join(install_path, 'bin'), item)
         if item != 'README':
             shutil.copy(s, d)

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -333,6 +333,11 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
     llvm_patch_path = os.path.join(patch_base,
                                    'llvm-{}.patch'.format(llvm_version))
 
+    cmake_cxx_flags = ['-Wno-deprecated-copy',
+                       '-Wno-pessimizing-move',
+                       '-Wno-redundant-move',
+                       '-Wno-init-list-lifetime']
+
     if llvm_version == 3.7:
         cmake_flags = ['-DCMAKE_INSTALL_PREFIX={}'.format(install_path),
                        '-DLLVM_TARGETS_TO_BUILD={}'.format(llvm_targets),
@@ -344,6 +349,8 @@ def install_clang_llvm(base_path, install_path, num_threads, llvm_targets):
                        '-DLLVM_TARGETS_TO_BUILD={}'.format(llvm_targets),
                        '-DCMAKE_BUILD_TYPE=Debug',
                        '-DLLVM_ENABLE_RTTI=ON',
+                       '-DCMAKE_CXX_STANDARD=17',
+                       '-DCMAKE_CXX_FLAGS={}'.format(' '.join(cmake_cxx_flags)),
                        '-DBUILD_SHARED_LIBS=ON',
                        '-DLLVM_EXTERNAL_PROJECTS="clang;"',
                        '-DLLVM_EXTERNAL_CLANG_SOURCE_DIR={}'

--- a/install_compiler.py
+++ b/install_compiler.py
@@ -276,7 +276,7 @@ def check_for_prerequisites(args):
     gcc_prerequisites = ['x86_64-linux-gnu-g++']
     for target in args.install_targets:
         gcc_prerequisites.append('{}-linux-gnu-gcc'.format(target))
-    other_prerequisites = ['flex', 'bison', 'git', 'cmake', 'make', 'zip']
+    other_prerequisites = ['flex', 'bison', 'git', 'cmake', 'make', 'zip', 'makeinfo']
 
     for prereq in gcc_prerequisites:
         out = _check_for_prerequisite(prereq)

--- a/patches/llvm/llvm-9.patch
+++ b/patches/llvm/llvm-9.patch
@@ -18883,3 +18883,15 @@ index 00000000000..8b2466bc060
 +declare void @llvm.experimental.stackmap(i64, i32, ...)
 +declare void @llvm.experimental.patchpoint.void(i64, i32, i8*, i32, ...)
 +declare i64 @llvm.experimental.patchpoint.i64(i64, i32, i8*, i32, ...)
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..4caa5ad4da07 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -1,6 +1,7 @@
+ #ifndef BENCHMARK_REGISTER_H
+ #define BENCHMARK_REGISTER_H
+ 
++#include <limits>
+ #include <vector>
+ 
+ #include "check.h"

--- a/tool/stack_metadata/Makefile
+++ b/tool/stack_metadata/Makefile
@@ -6,12 +6,12 @@ CHECK		:= check-stackmaps
 COMPRESS	:= compress
 
 POPCORN        := /usr/local/popcorn
-POPCORN_X86_64 := $(POPCORN)/x86_64
+POPCORN_ARCH	 := $(POPCORN)/$(shell uname -m)
 COMMON         := $(shell readlink -f ../../common)
 
 CC		:= gcc
 CFLAGS		:= -O3 -g -Wall -Iinclude -I$(COMMON)/include \
-		   -specs $(POPCORN_X86_64)/lib/musl-gcc.specs
+		   -specs $(POPCORN_ARCH)/lib/musl-gcc.specs
 LDFLAGS	:= -static
 LIB    	:= -lelf
 


### PR DESCRIPTION
This PR is based on issues that came upon a "clean" Ubuntu 21.10 Docker image:

- Update the prerequisites list and the README file for this.
- Fix use of base path (`--base-path` commandline option) used for:
  - Utility scripts installation
  - Makefile template generation  
 
  This allows installation of the Popcorn compiler without having to use the repo's top dir as the CWD.  
  Ideally, the `--base-path` value should be autodetected, but I had no time to make this happen.
 - Add hunk to LLVM 9 patch that triggers a failed compilation due to a missing standard header inclusion (`#include <limits>`).
   This is part of the benchmarking code of the project, thus inconsequential for the core Popcorn compiler.